### PR TITLE
make recovery-system available via bind mount

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -53,8 +53,8 @@ create_writable() {
     mkdir -p /writable/"$seed_path"
     mkdir -p /writable/"$snaps_path"
     mkdir -p /writable/system-data/boot
-    echo "copy recovery"
-    cp -r "$recovery_path"/* /writable/"$seed_path"/
+    echo "bind mount recovery"
+    mount -o bind "$recovery_path" /writable/"$seed_path"
     echo "create symlinks"
     snap_core=$(basename $(echo "$recovery_path"/snaps/core18_*.snap|tail -1))
     # fugly - hardcoded kernel name :( we need this so that the grub-bootenv

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -269,6 +269,10 @@ mountroot()
                 #        the RW mount and fsck dance etc here :/
                 #echo "LABEL=writable /writable auto defaults 0 0" >> "$fstab"
 		handle_writable_paths "$writable_paths" "$fstab"
+
+                # ensure the right recovery system is available
+                # (must be added *last*)
+                echo "/writable/system-data/var/lib/snapd/seed" "/var/lib/snapd/seed non bind 0 0" >> "$fstab"
 	fi
 
         # IMPORTANT: ensure we synced everything back to disk


### PR DESCRIPTION
Small PR that maks the recovery system available via a bind mount avoiding the copy (and the extra memory this requires on a /writable on tmpfs). This also need a tweak to the spike-tools https://github.com/cmatsuoka/spike-tools/pull/5