### PR TITLE
initramfs: use core20 instead of core18

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -56,7 +56,7 @@ create_writable() {
     echo "bind mount recovery"
     mount -o bind "$recovery_path" /writable/"$seed_path"
     echo "create symlinks"
-    snap_core=$(basename $(echo "$recovery_path"/snaps/core18_*.snap|tail -1))
+    snap_core=$(basename $(echo "$recovery_path"/snaps/core20_*.snap|tail -1))
     # fugly - hardcoded kernel name :( we need this so that the grub-bootenv
     # kernel name matches the kernel that is later seeded
     snap_kernel=$(basename $(echo "$recovery_path"/snaps/pc-kernel_*.snap|tail -1))
@@ -83,7 +83,7 @@ update_grub() {
 
     # snapd needs this (will be bind-mounted on /boot/grub later)
     grub-editenv "$system_boot_grubenv" create
-    grub-editenv "$system_boot_grubenv" set snap_core="core18_x1.snap"
+    grub-editenv "$system_boot_grubenv" set snap_core="core20_x1.snap"
     grub-editenv "$system_boot_grubenv" set snap_kernel="pc-kernel_x1.snap"
 
     umount /sys-recover

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -215,7 +215,7 @@ mountroot()
 
         if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ] || [ "$snap_mode" = "recover_reboot" ]; then
             # FIXME: these should come from the kernel cmdline
-            snap_core="core18_x1.snap"
+            snap_core="core20_x1.snap"
             snap_kernel="pc-kernel_x1.snap"
         fi
 

--- a/initramfs/testing/helpers.py
+++ b/initramfs/testing/helpers.py
@@ -143,7 +143,7 @@ class FIFO(Resource):
                     self.path, os.O_WRONLY | os.O_NONBLOCK | O_CLOEXEC)
             except OSError as exc:
                 if exc.errno == errno.ENXIO:
-                    asyncio.sleep(1)
+                    await asyncio.sleep(1)
 
         def proto_factory() -> asyncio.streams.FlowControlMixin:
             return asyncio.streams.FlowControlMixin()


### PR DESCRIPTION
Needs to land in sync with:
https://github.com/cmatsuoka/spike-tools/compare/master...mvo5:master

(it also merges core-build/master by accident, I can remove those commits if wanted).