### PR TITLE
many: use lodon sprint partiton names

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -37,8 +37,8 @@ if [ "$snap_mode" != "install" ] && [ "$snap_mode" != "recover" ] && [ "$snap_mo
 fi
 
 
-sys_recover_part="$(findfs LABEL=sys-recover || true)"
-system_boot_part="$(findfs LABEL=system-boot || true)"
+sys_recover_part="$(findfs LABEL=ubuntu-seed || true)"
+system_boot_part="$(findfs LABEL=ubuntu-boot || true)"
 
 syspath="$(dirname "$(realpath /sys/class/block/"$(basename "$sys_recover_part")")")"
 device="$(realpath /dev/block/"$(cat "$syspath"/dev)")"

--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -37,18 +37,18 @@ if [ "$snap_mode" != "install" ] && [ "$snap_mode" != "recover" ] && [ "$snap_mo
 fi
 
 
-sys_recover_part="$(findfs LABEL=ubuntu-seed || true)"
-system_boot_part="$(findfs LABEL=ubuntu-boot || true)"
+ubuntu_seed_part="$(findfs LABEL=ubuntu-seed || true)"
+ubuntu_boot_part="$(findfs LABEL=ubuntu-boot || true)"
 
-syspath="$(dirname "$(realpath /sys/class/block/"$(basename "$sys_recover_part")")")"
+syspath="$(dirname "$(realpath /sys/class/block/"$(basename "$ubuntu_seed_part")")")"
 device="$(realpath /dev/block/"$(cat "$syspath"/dev)")"
 
 
 create_writable_on_tmpfs() {
     echo "Create writable"
-    mkdir /sys-recover /writable /system-boot
-    mount -t vfat "$sys_recover_part" /sys-recover
-    mount -t vfat "$system_boot_part" /system-boot
+    mkdir /ubuntu-seed /writable /ubuntu-boot
+    mount -t vfat "$ubuntu_seed_part" /ubuntu-seed
+    mount -t vfat "$ubuntu_boot_part" /ubuntu-boot
     mount -t tmpfs tmpfs /writable
     mkdir -p /writable/"$seed_path"
     mkdir -p /writable/"$snaps_path"
@@ -71,8 +71,8 @@ create_writable_on_tmpfs() {
 
 update_grub() {
     echo "Update grub"
-    system_boot_grubenv="/system-boot/EFI/ubuntu/grubenv"
-    sys_recover_grubenv="/sys-recover/EFI/ubuntu/grubenv"
+    system_boot_grubenv="/ubuntu-boot/EFI/ubuntu/grubenv"
+    sys_recover_grubenv="/ubuntu-seed/EFI/ubuntu/grubenv"
     mkdir -p $(dirname "$system_boot_grubenv")
 
     # snapd needs this (will be bind-mounted on /boot/grub later)
@@ -80,12 +80,12 @@ update_grub() {
     grub-editenv "$system_boot_grubenv" set snap_core="core20_x1.snap"
     grub-editenv "$system_boot_grubenv" set snap_kernel="pc-kernel_x1.snap"
 
-    umount /sys-recover
-    umount /system-boot
+    umount /ubuntu-seed
+    umount /ubuntu-boot
 }
 
 
-recovery_root="/sys-recover/"
+recovery_root="/ubuntu-seed/"
 recovery_path="$recovery_root/systems/$recovery"
 seed_path="/system-data/var/lib/snapd/seed"
 snaps_path="/system-data/var/lib/snapd/snaps"

--- a/initramfs/scripts/local-premount/resize
+++ b/initramfs/scripts/local-premount/resize
@@ -1,5 +1,5 @@
 #! /bin/sh -e
-# initramfs local-premount script for resizing writable
+# initramfs local-premount script for resizing ubuntu-data
 
 PREREQ=""
 
@@ -21,7 +21,7 @@ grep -wq "snap_mode=install" /proc/cmdline && exit 0
 
 
 TMPFILE="/run/initramfs/old-table.txt"
-LOGFILE="/run/initramfs/resize-writable.log"
+LOGFILE="/run/initramfs/resize-ubuntu-data.log"
 
 wait-for-root "LABEL=ubuntu-data" "${ROOTDELAY:-180}" >/dev/null || true
 
@@ -34,11 +34,11 @@ for opt in $(cat /proc/cmdline); do
     esac
 done
 
-writable_part="$(findfs LABEL=ubuntu-data)"
+ubuntu_data_part="$(findfs LABEL=ubuntu-data)"
 
-syspath="$(dirname "$(realpath /sys/class/block/"$(basename "$writable_part")")")"
+syspath="$(dirname "$(realpath /sys/class/block/"$(basename "$ubuntu_data_part")")")"
 device="$(realpath /dev/block/"$(cat "$syspath"/dev)")"
-partition=$(cat "$syspath"/"$(basename "$writable_part")"/partition)
+partition=$(cat "$syspath"/"$(basename "$ubuntu_data_part")"/partition)
 
 device_size="$(($(cat "$syspath"/size)/2))"
 sum_size="$(($(grep "$(basename "$device")[a-z0-9]" /proc/partitions|\
@@ -104,7 +104,7 @@ min_free_space=$((device_size/10))
 resizeopts="-p"
 
 if [ "$min_free_space" -lt "$free_space" ]; then
-    echo "initrd: found more than 10% free space on disk, resizing ${writable_part}" >/dev/kmsg || true
+    echo "initrd: found more than 10% free space on disk, resizing ${ubuntu_data_part}" >/dev/kmsg || true
     echo "initrd: partition to full disk size, see ${LOGFILE} for details" >/dev/kmsg || true
     # back up the original partition table for later use or debugging
     parted -ms "$device" unit B print >$TMPFILE 2>/dev/null
@@ -129,8 +129,8 @@ if [ "$min_free_space" -lt "$free_space" ]; then
     {
         udevadm settle
         # check the filesystem before attempting re-size
-        e2fsck -fy "$writable_part"
+        e2fsck -fy "$ubuntu_data_part"
         # resize the filesystem to full size of the partition
-        resize2fs "$resizeopts" "$writable_part"
+        resize2fs "$resizeopts" "$ubuntu_data_part"
     } >>$LOGFILE 2>&1
 fi

--- a/initramfs/scripts/local-premount/resize
+++ b/initramfs/scripts/local-premount/resize
@@ -23,7 +23,7 @@ grep -wq "snap_mode=install" /proc/cmdline && exit 0
 TMPFILE="/run/initramfs/old-table.txt"
 LOGFILE="/run/initramfs/resize-writable.log"
 
-wait-for-root "LABEL=writable" "${ROOTDELAY:-180}" >/dev/null || true
+wait-for-root "LABEL=ubuntu-data" "${ROOTDELAY:-180}" >/dev/null || true
 
 # shellcheck disable=SC2013
 for opt in $(cat /proc/cmdline); do
@@ -34,7 +34,7 @@ for opt in $(cat /proc/cmdline); do
     esac
 done
 
-writable_part="$(findfs LABEL=writable)"
+writable_part="$(findfs LABEL=ubuntu-data)"
 
 syspath="$(dirname "$(realpath /sys/class/block/"$(basename "$writable_part")")")"
 device="$(realpath /dev/block/"$(cat "$syspath"/dev)")"
@@ -63,7 +63,7 @@ do_gpt()
 {
     DISK=$1
 
-    PARTNUM="$(sgdisk -p "$DISK"|grep writable|sed -r 's/^([^ ]*[ ]*){1}([^ ]*).*/\2/')"
+    PARTNUM="$(sgdisk -p "$DISK"|grep ubuntu-data|sed -r 's/^([^ ]*[ ]*){1}([^ ]*).*/\2/')"
     GUID="$(sgdisk -i "$PARTNUM" "$DISK"|grep unique| sed 's/^.*: //g')"
     FIRST="$(sgdisk -i "$PARTNUM" "$DISK"|grep ^First| sed 's/^.*: //g;s/ .*$//')"
 
@@ -80,8 +80,8 @@ do_gpt()
         echo "Setting GUID of partition $PARTNUM to $GUID"
         sgdisk -u "$PARTNUM":"$GUID" "$DISK"
         
-        echo "Setting name of $PARTNUM to writable"
-        sgdisk -c "$PARTNUM":writable "$DISK"
+        echo "Setting name of $PARTNUM to ubuntu-data"
+        sgdisk -c "$PARTNUM":ubuntu-data "$DISK"
         
         sgdisk -p "$DISK" >/run/initramfs/new-gpt-table.txt 2>/dev/null
     } >>$LOGFILE 2>&1

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -270,7 +270,7 @@ mountroot()
                 #echo "LABEL=writable /writable auto defaults 0 0" >> "$fstab"
 		handle_writable_paths "$writable_paths" "$fstab"
 
-                # ensure the right recovery system is available
+                # ensure the right recover system is available
                 # (must be added *last*)
                 echo "/writable/system-data/var/lib/snapd/seed" "/var/lib/snapd/seed non bind 0 0" >> "$fstab"
                 echo "/writable/system-data/var/lib/snapd/seed/snaps" "/var/lib/snapd/seed/snaps non bind 0 0" >> "$fstab"
@@ -288,7 +288,7 @@ mountroot()
 		grubdir="/boot/grub"
 		ubootdir="/boot/uboot"
 
-                tmpboot_mnt="/tmpmnt_system-boot"
+                tmpboot_mnt="/tmpmnt_ubuntu-boot"
                 mkdir -p $tmpboot_mnt
                 mount -o ro "$boot_partition" "$tmpboot_mnt"
 

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -228,7 +228,7 @@ mountroot()
         fi
 
         # always ensure writable is in a good state
-        writable_label="writable"
+        writable_label="ubuntu-data"
 
         if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ] || [ "$snap_mode" = "recover_reboot" ]; then
             writable_mnt="/writable"
@@ -280,7 +280,7 @@ mountroot()
         sync
 
 	# Request bootloader partition be mounted
-	boot_partition=$(findfs LABEL="system-boot" 2>/dev/null || :)
+	boot_partition=$(findfs LABEL="ubuntu-boot" 2>/dev/null || :)
 
 	if [ -n "$boot_partition" ]; then
 	        # determine bootloader type, we need to inspect the boot


### PR DESCRIPTION
During the London sprint we decided to use the following partition
names:
- ubuntu-seed (previously: sys-recover)
- ubuntu-boot (previously: system-boot)
- ubuntu-data (previously: writable)

This commit updates the code to use these names.

This will need a new pc gadget with updated grub.cfg(s)